### PR TITLE
Added friendly name filter and regex filters.

### DIFF
--- a/search-card.js
+++ b/search-card.js
@@ -79,6 +79,8 @@ class SearchCard extends LitElement {
 
   _valueChanged(ev) {
     var searchText = ev.target.value;
+    var searchRegex = new RegExp(searchText, 'i');
+
     this.data = [];
 
     if (!this.config || !this.hass || searchText === "") {
@@ -86,7 +88,13 @@ class SearchCard extends LitElement {
     }
 
     for (var entity_id in this.hass.states) {
-      if (entity_id.indexOf(searchText) >= 0) {
+      if (
+          (entity_id.search(searchRegex) >= 0) ||
+          (
+            "friendly_name" in this.hass.states[entity_id].attributes &&
+            this.hass.states[entity_id].attributes.friendly_name.search(searchRegex) >= 0
+          )
+        ) {
         this.data.push(entity_id);
       }
     }


### PR DESCRIPTION
Solves #4

I found out not checking if `friendly_name` exists some errors get thrown in the browser.

I added `friendly_name` searching.
I added regex search to friendly name and `entity_id` search.

Side effect is lack of case sensitivity.