### PR TITLE
Change X (error)

### DIFF
--- a/search-card.js
+++ b/search-card.js
@@ -58,11 +58,11 @@ class SearchCard extends ct.LitElement {
                        label="${this.search_text}">
             <ha-icon icon="mdi:magnify" id="searchIcon"
                        slot="prefix"></ha-icon>
-            <paper-icon-button slot="suffix"
+            <ha-icon-button slot="suffix"
                                @click="${this._clearInput}"
                                icon="mdi:close"
                                alt="Clear"
-                               title="Clear"></paper-icon-button>
+                               title="Clear"></ha-icon-button>
           </paper-input>
           ${results.length > 0 ?
               ct.LitHtml `<div id="count">Showing ${results.length} of ${this.results.length} results</div>`
@@ -181,6 +181,12 @@ class SearchCard extends ct.LitElement {
       }
       #searchIcon {
         padding: 10px;
+      }
+      input::-webkit-search-decoration,
+      input::-webkit-search-cancel-button,
+      input::-webkit-search-results-button,
+      input::-webkit-search-results-decoration {
+        display: none;
       }
     `;
   }

--- a/search-card.js
+++ b/search-card.js
@@ -54,7 +54,7 @@ class SearchCard extends ct.LitElement {
         <div id="searchContainer">
           <paper-input id="searchText"
                        @value-changed="${this._valueChanged}"
-                       no-label-float type="search"
+                       no-label-float type="text" autocomplete="off"
                        label="${this.search_text}">
             <ha-icon icon="mdi:magnify" id="searchIcon"
                        slot="prefix"></ha-icon>
@@ -181,12 +181,6 @@ class SearchCard extends ct.LitElement {
       }
       #searchIcon {
         padding: 10px;
-      }
-      input::-webkit-search-decoration,
-      input::-webkit-search-cancel-button,
-      input::-webkit-search-results-button,
-      input::-webkit-search-results-decoration {
-        display: none;
       }
     `;
   }


### PR DESCRIPTION
Add original X and remove browser-supplied X. Fixes #28. ~~Doesn't work, though, because there's a shadow root.~~ Changed to `type="text"` and used `autocomplete="off"` to bypass that!