### PR TITLE
Fix missing "clear" button icon in 2021.11+

### DIFF
--- a/search-card.js
+++ b/search-card.js
@@ -63,9 +63,8 @@ class SearchCard extends ct.LitElement {
                        slot="prefix"></ha-icon>
             <ha-icon-button slot="suffix"
                                @click="${this._clearInput}"
-                               icon="mdi:close"
                                alt="Clear"
-                               title="Clear"></ha-icon-button>
+                               title="Clear"><ha-icon icon="mdi:close"></ha-icon></ha-icon-button>
           </paper-input>
           ${results.length > 0 ?
               ct.LitHtml `<div id="count">Showing ${results.length} of ${this.results.length} results</div>`


### PR DESCRIPTION
HA 2021.11+ no longer supports "icon" property within "ha-icon-button" tag.  Fixed missing "clear" button icon as discussed here:

https://github.com/home-assistant/frontend/issues/10521