### PR TITLE
convert paper-input to ha-textfield

### DIFF
--- a/search-card.js
+++ b/search-card.js
@@ -55,17 +55,24 @@ class SearchCard extends ct.LitElement {
       return ct.LitHtml `
       <ha-card>
         <div id="searchContainer">
-          <paper-input id="searchText"
-                       @value-changed="${this._valueChanged}"
-                       no-label-float type="text" autocomplete="off"
-                       label="${this.search_text}">
-            <ha-icon icon="mdi:magnify" id="searchIcon"
-                       slot="prefix"></ha-icon>
-            <ha-icon-button slot="suffix"
-                               @click="${this._clearInput}"
-                               alt="Clear"
-                               title="Clear"><ha-icon icon="mdi:close"></ha-icon></ha-icon-button>
-          </paper-input>
+          <ha-textfield
+            id="searchText"
+            @input="${this._valueChanged}"
+            no-label-float type="text" autocomplete="off"
+            icon iconTrailing
+            label="${this.search_text}"
+          >
+            <ha-icon icon="mdi:magnify" id="searchIcon" slot="leadingIcon"></ha-icon>
+            <ha-icon-button
+              slot="trailingIcon"
+              @click="${this._clearInput}"
+              alt="Clear"
+              title="Clear"
+            >
+              <ha-icon icon="mdi:close"></ha-icon>
+            </ha-icon-button>
+          </ha-textfield>
+
           ${results.length > 0 ?
               ct.LitHtml `<div id="count">Showing ${results.length} of ${this.results.length} results</div>`
             : ''}
@@ -106,12 +113,15 @@ class SearchCard extends ct.LitElement {
   _clearInput()
   {
     this.shadowRoot.getElementById('searchText').value = '';
-    super.update()
+    this._updateSearchResults('');
   }
 
   _valueChanged(ev) {
     var searchText = ev.target.value;
+    this._updateSearchResults(searchText);
+  }
 
+  _updateSearchResults(searchText) {
     this.results = [];
     this.active_actions = [];
 
@@ -171,9 +181,14 @@ class SearchCard extends ct.LitElement {
     return ct.LitCSS `
       #searchContainer {
         width: 90%;
-        display: block;
+        display: flex;
         margin-left: auto;
         margin-right: auto;
+        padding-top: 5px;
+        padding-bottom: 5px;
+      }
+      #searchText {
+        flex-grow: 1;
       }
       #count {
         text-align: right;
@@ -186,9 +201,6 @@ class SearchCard extends ct.LitElement {
         margin-top: 15px;
         margin-left: auto;
         margin-right: auto;
-      }
-      #searchIcon {
-        padding: 10px;
       }
     `;
   }

--- a/search-card.js
+++ b/search-card.js
@@ -55,23 +55,25 @@ class SearchCard extends ct.LitElement {
       return ct.LitHtml `
       <ha-card>
         <div id="searchContainer">
-          <ha-textfield
-            id="searchText"
-            @input="${this._valueChanged}"
-            no-label-float type="text" autocomplete="off"
-            icon iconTrailing
-            label="${this.search_text}"
-          >
-            <ha-icon icon="mdi:magnify" id="searchIcon" slot="leadingIcon"></ha-icon>
-            <ha-icon-button
-              slot="trailingIcon"
-              @click="${this._clearInput}"
-              alt="Clear"
-              title="Clear"
+          <div id="searchTextFieldContainer">
+            <ha-textfield
+              id="searchText"
+              @input="${this._valueChanged}"
+              no-label-float type="text" autocomplete="off"
+              icon iconTrailing
+              label="${this.search_text}"
             >
-              <ha-icon icon="mdi:close"></ha-icon>
-            </ha-icon-button>
-          </ha-textfield>
+              <ha-icon icon="mdi:magnify" id="searchIcon" slot="leadingIcon"></ha-icon>
+              <ha-icon-button
+                slot="trailingIcon"
+                @click="${this._clearInput}"
+                alt="Clear"
+                title="Clear"
+              >
+                <ha-icon icon="mdi:close"></ha-icon>
+              </ha-icon-button>
+            </ha-textfield>
+          </div>
 
           ${results.length > 0 ?
               ct.LitHtml `<div id="count">Showing ${results.length} of ${this.results.length} results</div>`
@@ -181,9 +183,12 @@ class SearchCard extends ct.LitElement {
     return ct.LitCSS `
       #searchContainer {
         width: 90%;
-        display: flex;
+        display: block;
         margin-left: auto;
         margin-right: auto;
+      }
+      #searchTextFieldContainer {
+        display: flex;
         padding-top: 5px;
         padding-bottom: 5px;
       }


### PR DESCRIPTION
This should fix the issue in #44 

I migrated `paper-input` to `ha-textfield`. The interface is slightly different so I have done my best to ensure parity. The new field is styled slightly differently but matches the HA inputs.

Old on top, new on bottom
![image](https://github.com/postlund/search-card/assets/6422129/2fae4d75-a378-435b-8b03-4517c8e737bb)

I don't use the full functionality of search-card so I only could test what I use.

Searching example
![image](https://github.com/postlund/search-card/assets/6422129/4071093e-b358-45b1-b6bc-87f54bbd5817)
